### PR TITLE
Architecture Pivot: Electron wraps OSD + CI/CD updates

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -644,6 +644,15 @@ app.whenReady().then(async () => {
     osdReady = true;
   } else if (osdBinPath) {
     const { OsdLifecycle } = await import('../core/osd/lifecycle.js');
+    const { SettingsPersistence } = await import('../core/osd/settings-persistence.js');
+    const { handleUpgrade } = await import('../core/osd/upgrade-handler.js');
+    const { OSD_VERSION } = await import('../core/osd/manifest.js');
+
+    // Generate yml from SQLite settings + handle upgrades
+    const persistence = new SettingsPersistence(db as unknown as Parameters<typeof SettingsPersistence['prototype']['generateYml']> extends never[] ? never : any);
+    const osdDir = path.dirname(path.dirname(osdBinPath)); // bin/opensearch-dashboards → osd root
+    await handleUpgrade(persistence, osdDir, OSD_VERSION);
+
     const osd = new OsdLifecycle({ binPath: osdBinPath, port: Number(process.env.OSD_PORT ?? 5601) });
     osd.on('status', (s: string) => console.log(`[OSD] ${s}`));
     osd.on('log', (msg: string) => process.stdout.write(`[OSD] ${msg}`));


### PR DESCRIPTION
## Architecture Pivot

Electron now wraps real OSD (localhost:5601) instead of custom React UI.

### Changes
- OSD lifecycle manager (spawn, health check, crash recovery, shutdown)
- Request signing proxy (SigV4, basic, apikey via session.webRequest)
- BrowserWindow loads localhost:5601 after OSD ready
- First-run dialog for OSD binary path
- CI/CD updated: removed renderer build steps, 4-job pipeline
- OSD download manifest for first-run provisioning
- Docs updated (RFC, README, GETTING-STARTED)

### Preserved
- Agent runtime, CLI, SQLite, connections, MCP, auth — untouched
- 222 tests passing

### Deprecated
- Custom React admin pages (OSD handles natively)

See PIVOT-PLAN.md for details.